### PR TITLE
fix: correct parsing of quoted values with equals sign in `.env` files

### DIFF
--- a/src/modules/load-env/__tests__/index.spec.ts
+++ b/src/modules/load-env/__tests__/index.spec.ts
@@ -37,7 +37,8 @@ EXAMPLE_8="false"
 EXAMPLE_9=42
 EXAMPLE_10="42"
 EXAMPLE_11=["42", true, 123, { "key": "value" }]
-EXAMPLE_12={ "key": "value" }`;
+EXAMPLE_12={ "key": "value" }
+EXAMPLE_13="abc=123"`;
 
     createEnvFile(envContent);
 
@@ -54,6 +55,7 @@ EXAMPLE_12={ "key": "value" }`;
       EXAMPLE_10: string;
       EXAMPLE_11: any[];
       EXAMPLE_12: Record<string, any>;
+      EXAMPLE_13: string;
     }>({ path: tempEnvPath });
 
     expect(process.env.EXAMPLE_1).toEqual("John Doe");
@@ -81,6 +83,7 @@ EXAMPLE_12={ "key": "value" }`;
     expect(envs.EXAMPLE_10).toEqual("42");
     expect(envs.EXAMPLE_11).toEqual(["42", true, 123, { key: "value" }]);
     expect(envs.EXAMPLE_12).toEqual({ key: "value" });
+    expect(envs.EXAMPLE_13).toEqual("abc=123");
   });
 
   it("Should load variables from a real .env file with comments", () => {

--- a/src/modules/load-env/helpers/parse-env-file.ts
+++ b/src/modules/load-env/helpers/parse-env-file.ts
@@ -23,7 +23,8 @@ export const parseEnvFile = (
       return;
     }
 
-    const [key, value] = cleanedLine.split("=");
+    const [key, ...rest] = cleanedLine.split("=");
+    const value = rest.join("=");
 
     if (key && value) {
       const trimmedKey = key.trim();


### PR DESCRIPTION
**Description**

This PR fixes the parsing logic for environment variables in `.env` files, ensuring that quoted values containing an equals sign (`=`) are handled correctly. The parser now splits only on the first `=`, preserving the full value.

**Related Issue**
Closes #[issue-number]

**Changes**
- Updated the parsing logic in `parseEnvFile` to split only on the first `=`.
- Added/updated tests to cover quoted values with `=`.

**Checklist**
- [x] All tests pass
- [x] Linked to the related issue

This will close #69 