### PR TITLE
fix: header value converted to lowercase

### DIFF
--- a/src/modules/super-request/__tests__/index-e2e.spec.ts
+++ b/src/modules/super-request/__tests__/index-e2e.spec.ts
@@ -133,6 +133,31 @@ describe("Super Request - end to end testing", () => {
     app.close();
   });
 
+  it("Should parse JWT token authentication header in POST method", async () => {
+    let requestHeaders;
+
+    const app = App();
+    app.parseData();
+
+    app.post("/auth", (req: Request, res: Response) => {
+      requestHeaders = req.headers;
+      res.status(200).end();
+    });
+
+    const token =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.KMUFsIDTnFmyG3nMiGM6H9FNFUROf3wh7SmqJp-QV30";
+
+    const response = await superRequest(app).post("/auth", undefined, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    validateSuccess(response);
+
+    expect(requestHeaders).toBeDefined();
+    expect(requestHeaders!.authorization).toBeDefined();
+    expect(requestHeaders!.authorization).toEqual(`Bearer ${token}`);
+  });
+
   it("Should handle PUT requests", async () => {
     let requestBody;
 

--- a/src/modules/super-request/helpers/create-http-request.ts
+++ b/src/modules/super-request/helpers/create-http-request.ts
@@ -39,7 +39,7 @@ export const createHttpRequest = (params: {
     if (Object.prototype.hasOwnProperty.call(headers, key)) {
       const lowercaseKey = key.toLowerCase();
       const value = headers[key];
-      lowercaseHeaders[lowercaseKey] = value.toLowerCase();
+      lowercaseHeaders[lowercaseKey] = value;
     }
   }
 

--- a/src/modules/validate-route-data/__tests__/index.spec.ts
+++ b/src/modules/validate-route-data/__tests__/index.spec.ts
@@ -50,7 +50,7 @@ describe("Validate Route Data - end to end testing using super request", () => {
         headers: {
           authorization: "success",
           "content-type": "application/json",
-          "x-custom-header": "customvalue",
+          "x-custom-header": "customValue",
         },
         params: {
           string: "any@mail.com",


### PR DESCRIPTION
**Checklist**
- [x] All tests pass
- [x] Linked to the related issue

This PR fixes header values that are converted to lower case in the `super-request` module.

**Example**
Value Sent:
```bash
Barrear eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0.KMUFsIDTnFmyG3nMiGM6H9FNFUROf3wh7SmqJp-QV30
```
Value Received in Request
```bash
Barrear eyjhbgcioijiuzi1niisinr5cci6ikpxvcj9.eyjzdwiioiixmjm0nty3odkwiiwibmftzsi6ikpvag4grg9li iwiywrtaw4ionrydwusimlhdci6mtuxnjizotaymn0.kmufsidtnfmyg3nmigm6h9fnfurof3wh7smqjp-qv30

```

**Changes**
- Updated the section that converts the header value to lowercase.
- Added/updated tests to cover case-sensitive values in the header value.

**Checklist**
- [x] All tests pass
- [x] Linked to the related issue.

This will close #68 
